### PR TITLE
Change highlight.js/vue to peerDependencies to enforce versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tslib": "^2.2.0",
     "typescript": "^4.2.4"
   },
-  "dependencies": {
+  "peerDependencies": {
     "highlight.js": "^11.0.1",
     "vue": "^3"
   },


### PR DESCRIPTION
As discussed in #12, changing `highlight.js` and `vue` to `peerDependencies` will force the user to have compatible versions to prevent multiple singleton resolutions

https://nodejs.org/en/blog/npm/peer-dependencies/