### PR TITLE
Fix A11Y issue

### DIFF
--- a/src/vue.ts
+++ b/src/vue.ts
@@ -68,6 +68,7 @@ const component = defineComponent({
             h('code', {
                 class: this.className,
                 innerHTML: this.highlightedCode,
+                tabindex: '0',
             }),
         ])
     },


### PR DESCRIPTION
This change allows you to tab to the code box when a scrollbar appears.

This fixes the following issue:

![scroll-a11y](https://user-images.githubusercontent.com/4629794/184040473-2fafecc9-26f1-4ff5-9684-0346c0f4990b.png)

Essentially if there is a code block with a line of code so long that it breaks the box, then a `overflow: auto` scroll bar will appear, but keyboard users need to be able to TAB to the element and scroll it. If no scrollbar appears, the element is be skipped during tabbing, like usual.

More details:

* https://dequeuniversity.com/rules/axe/html/4.4/scrollable-region-focusable?application=vue-axe