### PR TITLE
Fix TS1444 error

### DIFF
--- a/src/vue.ts
+++ b/src/vue.ts
@@ -1,4 +1,4 @@
-import { ref, h, computed, defineComponent, Plugin, watch } from 'vue'
+import { ref, h, computed, defineComponent, type Plugin, watch } from 'vue'
 import hljs from 'highlight.js/lib/core'
 import { escapeHtml } from './lib/utils'
 


### PR DESCRIPTION
When both "preserveValueImports" and "isolatedModules" are enabled, you must import using type-only imports.