### PR TITLE
Fix language prop being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+- Fix `language` prop being ignored unless `autodetect` is explicitly set to `false` (#41)
+
 ## 2.1.2
 
 - Default to `tabindex="0"` on the internal `<code>` element to allow keyboard scrolling when a scrollbar is applied to the element. This resolves an accessibility issue found by Vue-Axe. (#33)

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -27,7 +27,7 @@ const component = defineComponent({
             language.value = newLanguage
         })
 
-        const autodetect = computed(() => props.autodetect || !language.value)
+        const autodetect = computed(() => props.autodetect && !language.value)
         const cannotDetectLanguage = computed(() => !autodetect.value && !hljs.getLanguage(language.value))
 
         const className = computed((): string => {


### PR DESCRIPTION
Fixes a logic error which causes the language prop to be ignored unless autodetection is explicit disabled.

For example, in 2.1.2, the following is highlighted as `cpp` rather than `shell`, even though we have asked for `shell`:

```html
<highlightjs language="shell" code="#include <iostream>"></highlightjs>
```

I've tested the fix over a wide range of cases. The example code I used is

```
#include <iostream>; import os
```

because it is autodetected as `stan` but renders differently for `stan`, `cpp` and `shell`, which means you can visually tell how it has been highlighted.

I believe the fix provides reasonable results in all cases.

![image](https://user-images.githubusercontent.com/23739434/206213683-7573b9ad-3c4d-407a-aa41-3f1447eb425e.png)

Fixes #41.